### PR TITLE
Bridge monitor update

### DIFF
--- a/monitoring/bridge-monitor/.gitignore
+++ b/monitoring/bridge-monitor/.gitignore
@@ -1,2 +1,4 @@
 README.md
 mainnet.txt
+bnbcli
+bridge-watchd

--- a/monitoring/bridge-monitor/bridge-watchdog/daemon-cmds.go
+++ b/monitoring/bridge-monitor/bridge-watchdog/daemon-cmds.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	installD = "install the harmony-watchdog service"
-	removeD  = "remove the harmony-watchdog service"
-	startD   = "start the harmony-watchdog service"
-	stopD    = "stop the harmony-watchdog service"
-	statusD  = "check status of the harmony-watchdog service"
+	installD = "install the bridge-watchdog service"
+	removeD  = "remove the bridge-watchdog service"
+	startD   = "start the bridge-watchdog service"
+	stopD    = "stop the bridge-watchdog service"
+	statusD  = "check status of the bridge-watchdog service"
 	mCmd     = "monitor"
 	mFlag    = "bnbPath"
 	mDescr   = "path to bnbcli binary [required]"

--- a/monitoring/bridge-monitor/bridge-watchdog/pager.go
+++ b/monitoring/bridge-monitor/bridge-watchdog/pager.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"fmt"
-
 	pd "github.com/PagerDuty/go-pagerduty"
 )
 
 func notify(serviceKey, msg string) error {
-	resp, err := pd.CreateEvent(pd.Event{
+	_, err := pd.CreateEvent(pd.Event{
 		Type:        "trigger",
 		ServiceKey:  serviceKey,
 		Description: msg,
 	})
-	fmt.Println(resp, err)
 	return err
 }

--- a/monitoring/bridge-monitor/bridge-watchdog/root.go
+++ b/monitoring/bridge-monitor/bridge-watchdog/root.go
@@ -42,8 +42,8 @@ var (
 	}
 	w      *cobraSrvWrapper = &cobraSrvWrapper{nil}
 	bnbcliPath string
-	stdlog *log.Logger
-	errlog *log.Logger
+	stdLog *log.Logger
+	errLog *log.Logger
 	// Add services here that we might want to depend on, see all services on
 	// the machine with systemctl list-unit-files
 	dependencies    = []string{}
@@ -99,8 +99,9 @@ func (service *Service) monitorNetwork() error {
 						BNB CLI fetch failed. Exiting. %s
 						`, oops))
 				if e != nil {
-					stdlog.Println(e)
+					errLog.Println(e)
 				}
+				errLog.Println(oops)
 				os.Exit(-1)
 			}
 
@@ -113,9 +114,10 @@ func (service *Service) monitorNetwork() error {
 							EtherScan balance fetch failed for 1 hour. Exiting. Error: %s
 							`, err))
 					if e != nil {
-						stdlog.Println(e)
+						errLog.Println(e)
 					}
 					// If failing for 1 hour, exit
+					errLog.Println(err)
 					os.Exit(-1)
 				}
 				tryAgainCounter = 10
@@ -129,8 +131,9 @@ func (service *Service) monitorNetwork() error {
 							EtherScan balance fetch failed for 1 hour. Exiting. Error: %s
 							`, error))
 					if e != nil {
-						stdlog.Println(e)
+						errLog.Println(e)
 					}
+					errLog.Println(error)
 					os.Exit(-1)
 				}
 				tryAgainCounter = 10
@@ -143,7 +146,7 @@ func (service *Service) monitorNetwork() error {
 			totalBalance := normed.Add(ethSiteBal)
 			diff := totalBalance.Sub(expectedBalance).Abs()
 			if reportCounter > 30 {
-				stdlog.Printf(`
+				stdLog.Printf(`
 Expected Balance: %s
 
 Calculated Balance: %s = (%s / %s) + %s
@@ -169,7 +172,7 @@ Deviation: %s
 						Deviation: %s
 						`, normed, ethSiteBal, expectedBalance, totalBalance, bnb, base, ethSiteBal, diff))
 					if e != nil {
-						stdlog.Println(e)
+						stdLog.Println(e)
 					}
 			}
 		}
@@ -181,8 +184,8 @@ Deviation: %s
 	for {
 		select {
 		case killSignal := <-interrupt:
-			stdlog.Println("Got signal:", killSignal)
-			stdlog.Println("Stoping listening on ", listener.Addr())
+			stdLog.Println("Got signal:", killSignal)
+			stdLog.Println("Stoping listening on ", listener.Addr())
 			listener.Close()
 			if killSignal == os.Interrupt {
 				return errSysIntrpt
@@ -298,8 +301,8 @@ func pullEtherScan(data string) (Dec, error) {
 }
 
 func init() {
-	stdlog = log.New(os.Stdout, "", log.Ldate|log.Ltime)
-	errlog = log.New(os.Stderr, "", log.Ldate|log.Ltime)
+	stdLog = log.New(os.Stdout, "", log.Ldate|log.Ltime)
+	errLog = log.New(os.Stderr, "", log.Ldate|log.Ltime)
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Show version",


### PR DESCRIPTION
Add std print for deviation every 30 minutes
Add error log when daemon exits 

To check on bridge watch daemon:
$ systemctl status bridge-watchd.service
● bridge-watchd.service - Monitor bridge discrepencies
   Loaded: loaded (/etc/systemd/system/bridge-watchd.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2019-10-16 14:25:37 PDT; 37min ago
  Process: 23839 ExecStartPre=/bin/rm -f /var/run/bridge-watchd.pid (code=exited, status=0/SUCCESS)
 Main PID: 23840 (bridge-watchd)
    Tasks: 12 (limit: 4915)
   Memory: 10.4M
   CGroup: /system.slice/bridge-watchd.service
           └─23840 /home/harmony/go/src/github.com/harmony-one/harmony-ops/monitoring/bridge-monitor/bridge-watchd monitor --bnbPath /usr/l

Oct 16 14:25:37 EngConferencePC systemd[1]: Starting Monitor bridge discrepencies...
Oct 16 14:25:37 EngConferencePC systemd[1]: Started Monitor bridge discrepencies.
Oct 16 14:56:42 EngConferencePC bridge-watchd[23840]: 2019/10/16 14:56:42
Oct 16 14:56:42 EngConferencePC bridge-watchd[23840]: Expected Balance: 152818477.146499980000000000
Oct 16 14:56:42 EngConferencePC bridge-watchd[23840]: Calculated Balance: 152817969.496499980000000000 = (8301827181285854.0000000000000000
Oct 16 14:56:42 EngConferencePC bridge-watchd[23840]: Deviation: 507.650000000000000000