### PR TITLE
API test automation improvements with create-validator test

### DIFF
--- a/test-automation/api-tests/README.md
+++ b/test-automation/api-tests/README.md
@@ -7,7 +7,7 @@ Related internal [gitbook](https://app.gitbook.com/@harmony-one/s/onboarding-wik
 - Make sure that you have `pexpect` module for python (https://pypi.org/project/pexpect/). 
 - Make sure that you have `jq` installed.
 - Make sure to have the CLI binary in this directory with the name `hmy` (or specifiy the binary path as an option).
-- Make sure the CLI version is v113 or newer (that is commit `9e7175544778aa12061cd135e826131fed5f3a0f` or newer of *go-sdk*)
+- Make sure the CLI version is v132 or newer (that is commit `03621a931518dea582d4327671e0add33296a88d` or newer of *go-sdk*)
 
 ## Setup
 The test will require at least 2 keys to accounts that have funds on the network that you are testing. 
@@ -46,10 +46,11 @@ There are some options for the python script, here is the output of the help mes
 ```
 usage: test.py [-h] [--test_dir TEST_DIR] [--iterations ITERATIONS]
                [--rpc_endpoint_src HMY_ENDPOINT_SRC]
-               [--rpc_endpoint_dst HMY_ENDPOINT_DST]
-               [--exp_endpoint HMY_EXP_ENDPOINT] [--delay TXN_DELAY]
-               [--chain_id CHAIN_ID] [--cli_path HMY_BINARY_PATH]
-               [--cli_passphrase PASSPHRASE] [--keystore KEYS_DIR]
+               [--rpc_endpoint_dst HMY_ENDPOINT_DST] [--src_shard SRC_SHARD]
+               [--dst_shard DST_SHARD] [--exp_endpoint HMY_EXP_ENDPOINT]
+               [--delay TXN_DELAY] [--chain_id CHAIN_ID]
+               [--cli_path HMY_BINARY_PATH] [--cli_passphrase PASSPHRASE]
+               [--keystore KEYS_DIR] [--do_staking_test]
 
 Wrapper python script to test API using newman.
 
@@ -65,6 +66,12 @@ optional arguments:
   --rpc_endpoint_dst HMY_ENDPOINT_DST
                         Destination endpoint for Cx. Default is
                         https://api.s1.b.hmny.io/
+  --src_shard SRC_SHARD
+                        The source shard of the Cx. Default assumes associated
+                        shard from src endpoint.
+  --dst_shard DST_SHARD
+                        The destination shard of the Cx. Default assumes
+                        associated shard from dst endpoint.
   --exp_endpoint HMY_EXP_ENDPOINT
                         Default is http://e0.b.hmny.io:5000/
   --delay TXN_DELAY     The time to wait before checking if a Cx/Tx is on the
@@ -75,15 +82,16 @@ optional arguments:
                         ABSOLUTE PATH of CLI binary. Default uses the CLI
                         included in pyhmy module
   --cli_passphrase PASSPHRASE
-                        Passphrase used to unlock the keystore. Default is
-                        'harmony-one'
+                        Passphrase used to unlock the keystore. Default is ''
   --keystore KEYS_DIR   Direcotry of keystore to import. Must follow the
                         format of CLI's keystore. Default is
                         ./TestnetValidatorKeys
+  --do_staking_test     Toggle (on) the staking tests.
 ```
 
 ## Notes
-  - This script makes the assumption that there are only 2 shard and will only send a cross shard transactions between shard 0 and shard 1. 
+  - If no source or destination shard is provided, the script will infer the respective shard from the source and destination endpoints (given that it is a known format -- reference code for details).
+  - The chain_id option can be set to localnet if one needs to run the tests on localnet. This is just a creature comfort as the localnet uses the testnet chain ID
   - The raw transaction used in this test is **always** a cross-shard transaction. 
   - It is recommended to wait around 30 seconds for a Cx to finalize.
   - Each iteration will try the tests **on the same raw transaction**.

--- a/test-automation/api-tests/localnet_test.sh
+++ b/test-automation/api-tests/localnet_test.sh
@@ -51,9 +51,9 @@ sleep $wait
 echo "Testing Cx from s0 to s1"
 python3 test.py --test_dir=./tests/no-explorer/ --rpc_endpoint_src="http://localhost:9500/" \
     --rpc_endpoint_dst="http://localhost:9501/" --keystore=./LocalnetValidatorKeys/ \
-    --chain_id="localnet" --delay=${delay} --iterations=${iters}
+    --chain_id="localnet" --do_staking_test --delay=${delay} --iterations=${iters}
 
 echo "Testing Cx from s1 to s0"
 python3 test.py --test_dir=./tests/no-explorer/ --rpc_endpoint_src="http://localhost:9501/" \
     --rpc_endpoint_dst="http://localhost:9500/" --keystore=./LocalnetValidatorKeys/ \
-    --chain_id="localnet" --delay=${delay} --iterations=${iters}
+    --chain_id="localnet" --do_staking_test --delay=${delay} --iterations=${iters}

--- a/test-automation/api-tests/pyhmy/cli.py
+++ b/test-automation/api-tests/pyhmy/cli.py
@@ -81,6 +81,14 @@ class HmyCLI:
                 name, address = columns
                 self._addresses[name.strip()] = address
 
+    def check_address(self, address) -> bool:
+        """
+        :param address: A 'one1...' address.
+        :return: T/F If the address is in the CLI's keystore.
+        """
+        self._sync_addresses()
+        return address in self._addresses.values()
+
     def get_address(self, name) -> str:
         """
         :param name: The alias of a key used in the CLI's keystore.
@@ -92,7 +100,7 @@ class HmyCLI:
             self._sync_addresses()
             return self._addresses.get(name, None)
 
-    def remove_address(self, name) -> None:
+    def remove_account(self, name) -> None:
         """
         :param name: The alias of a key used in the CLI's keystore.
         """

--- a/test-automation/api-tests/tests/default/env.json
+++ b/test-automation/api-tests/tests/default/env.json
@@ -1,1 +1,64 @@
-{"id": "39a65f6d-2c15-47f9-8fab-33aa08aa4ed9", "name": "Automated Test Env (DO NOT CHANGE)", "values": [{"key": "txHash", "value": "0x1bd3d8c23d85676e64508edfb84128e51a0d7e8fa097ed325a3d2ba1d672a6c0", "enabled": true}, {"key": "accountAddress", "value": "one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc", "enabled": true}, {"key": "blockHash", "value": "0x2677e80589215ebede7e4ea1df3988f96751bedc76c09a859aceefb6d30a628f", "enabled": true}, {"key": "blockNumber", "value": "0x5baad", "enabled": true}, {"key": "txIndex", "value": "0x0", "enabled": true}, {"key": "blockTxCount", "value": null, "enabled": true}, {"key": "getBlockByHash_number", "value": "0x5baad", "enabled": true}, {"key": "rawTransaction", "value": "0xf86508808252080180949ad139ffc9f62a7c215766de5901124402cbe531843b9aca008026a0eecfdfaf7e5a8ed54f0e4eee6f416e4cb7ebd66f8616ed8a5dd2d7a60d63c15ea0139f2b39fe194420678d4dc2ce9771b413f4b93e6c7f3efe756ff4135741089e", "enabled": true}, {"key": "tx_beta_endpoint", "value": "http://e1.t.hmny.io:5000/", "enabled": true}, {"key": "txn_delay", "value": 30, "enabled": true}, {"key": "source_shard", "value": 1, "enabled": true}], "_postman_variable_scope": "environment", "_postman_exported_at": "2019-10-23T21:20:51.340Z", "_postman_exported_using": "Postman/7.9.0"}
+{
+	"id": "39a65f6d-2c15-47f9-8fab-33aa08aa4ed9",
+	"name": "Automated Test Env (DO NOT CHANGE)",
+	"values": [
+		{
+			"key": "txHash",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "accountAddress",
+			"value": "one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc",
+			"enabled": true
+		},
+		{
+			"key": "blockHash",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "blockNumber",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "txIndex",
+			"value": "0x0",
+			"enabled": true
+		},
+		{
+			"key": "blockTxCount",
+			"value": null,
+			"enabled": true
+		},
+		{
+			"key": "getBlockByHash_number",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "rawTransaction",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "tx_beta_endpoint",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "txn_delay",
+			"value": "40",
+			"enabled": true
+		},
+		{
+			"key": "source_shard",
+			"value": "0",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2019-11-13T06:44:05.285Z",
+	"_postman_exported_using": "Postman/7.9.0"
+}

--- a/test-automation/api-tests/tests/default/test.json
+++ b/test-automation/api-tests/tests/default/test.json
@@ -6,6 +6,56 @@
 	},
 	"item": [
 		{
+			"name": "hmy_latestHeader",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "ed50e868-8f64-4eeb-9247-4cf135fd0ca7",
+						"exec": [
+							"console.log(\"Request Body\")",
+							"console.log(pm.request.body.raw)",
+							"console.log()",
+							"console.log(\"Response\")",
+							"console.log(pm.response.json())",
+							"",
+							"pm.test(\"Response should not contain errors.\", () => {",
+							"    pm.expect('error' in pm.response.json()).to.equal(false);",
+							"})",
+							"",
+							"pm.test(\"Response should have non-null result field.\", () => {",
+							"    pm.expect('result' in pm.response.json()).to.equal(true);",
+							"    pm.expect(pm.response.json().result).not.equal(null);",
+							"})",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"jsonrpc\":\"2.0\", \"method\":\"hmy_latestHeader\", \"params\":[], \"id\":1}"
+				},
+				"url": {
+					"raw": "{{hmy_endpoint_src}}",
+					"host": [
+						"{{hmy_endpoint_src}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "hmy_sendRawTransaction",
 			"event": [
 				{
@@ -139,6 +189,8 @@
 							"console.log(\"Response\")",
 							"console.log(pm.response.json())",
 							"",
+							"// TODO: write more logic to resend and retest Cx if getCxByHash failed",
+							"",
 							"pm.test(\"Response should not contain errors.\", () => {",
 							"    pm.expect('error' in pm.response.json()).to.equal(false);",
 							"})",
@@ -189,6 +241,8 @@
 							"console.log(\"Response\")",
 							"console.log(pm.response.json())",
 							"",
+							"// TODO: write more logic to resend and retest Cx if getCxByHash failed",
+							"",
 							"pm.test(\"Response should not contain errors.\", () => {",
 							"    pm.expect('error' in pm.response.json()).to.equal(false);",
 							"})",
@@ -219,12 +273,12 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\":\"2.0\",\"method\":\"hmy_getCXReceiptByHash\",\"params\":[\"{{txHash}}\"],\"id\":1}"
+					"raw": "{\"jsonrpc\":\"2.0\",\"method\":\"hmy_resendCx\",\"params\":[\"{{txHash}}\"],\"id\":1}"
 				},
 				"url": {
-					"raw": "{{hmy_endpoint_dst}}",
+					"raw": "{{hmy_endpoint_src}}",
 					"host": [
-						"{{hmy_endpoint_dst}}"
+						"{{hmy_endpoint_src}}"
 					]
 				}
 			},

--- a/test-automation/api-tests/tests/no-explorer/env.json
+++ b/test-automation/api-tests/tests/no-explorer/env.json
@@ -1,1 +1,64 @@
-{"id": "39a65f6d-2c15-47f9-8fab-33aa08aa4ed9", "name": "Automated Test Env (DO NOT CHANGE)", "values": [{"key": "txHash", "value": "0x1bd3d8c23d85676e64508edfb84128e51a0d7e8fa097ed325a3d2ba1d672a6c0", "enabled": true}, {"key": "accountAddress", "value": "one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc", "enabled": true}, {"key": "blockHash", "value": "0x2677e80589215ebede7e4ea1df3988f96751bedc76c09a859aceefb6d30a628f", "enabled": true}, {"key": "blockNumber", "value": "0x5baad", "enabled": true}, {"key": "txIndex", "value": "0x0", "enabled": true}, {"key": "blockTxCount", "value": null, "enabled": true}, {"key": "getBlockByHash_number", "value": "0x5baad", "enabled": true}, {"key": "rawTransaction", "value": "0xf86506808252080180949ad139ffc9f62a7c215766de5901124402cbe531843b9aca008026a017342cca738ed522fad6462047f7010d6dad8210a31cb4dc5fd4233332af2616a0407a7462396acbd461cde28bf120e2be90cf7e6f53aeba7d07f16f77239a331f", "enabled": true}, {"key": "tx_beta_endpoint", "value": "http://e1.b.hmny.io:5000/", "enabled": true}, {"key": "txn_delay", "value": 30, "enabled": true}, {"key": "source_shard", "value": "0", "enabled": true}], "_postman_variable_scope": "environment", "_postman_exported_at": "2019-10-23T21:20:51.340Z", "_postman_exported_using": "Postman/7.9.0"}
+{
+	"id": "39a65f6d-2c15-47f9-8fab-33aa08aa4ed9",
+	"name": "Automated Test Env (DO NOT CHANGE)",
+	"values": [
+		{
+			"key": "txHash",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "accountAddress",
+			"value": "one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc",
+			"enabled": true
+		},
+		{
+			"key": "blockHash",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "blockNumber",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "txIndex",
+			"value": "0x0",
+			"enabled": true
+		},
+		{
+			"key": "blockTxCount",
+			"value": null,
+			"enabled": true
+		},
+		{
+			"key": "getBlockByHash_number",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "rawTransaction",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "tx_beta_endpoint",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "txn_delay",
+			"value": "40",
+			"enabled": true
+		},
+		{
+			"key": "source_shard",
+			"value": "0",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2019-11-13T06:44:05.285Z",
+	"_postman_exported_using": "Postman/7.9.0"
+}

--- a/test-automation/api-tests/tests/no-explorer/test.json
+++ b/test-automation/api-tests/tests/no-explorer/test.json
@@ -6,6 +6,56 @@
 	},
 	"item": [
 		{
+			"name": "hmy_latestHeader",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "ed50e868-8f64-4eeb-9247-4cf135fd0ca7",
+						"exec": [
+							"console.log(\"Request Body\")",
+							"console.log(pm.request.body.raw)",
+							"console.log()",
+							"console.log(\"Response\")",
+							"console.log(pm.response.json())",
+							"",
+							"pm.test(\"Response should not contain errors.\", () => {",
+							"    pm.expect('error' in pm.response.json()).to.equal(false);",
+							"})",
+							"",
+							"pm.test(\"Response should have non-null result field.\", () => {",
+							"    pm.expect('result' in pm.response.json()).to.equal(true);",
+							"    pm.expect(pm.response.json().result).not.equal(null);",
+							"})",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"jsonrpc\":\"2.0\", \"method\":\"hmy_latestHeader\", \"params\":[], \"id\":1}"
+				},
+				"url": {
+					"raw": "{{hmy_endpoint_src}}",
+					"host": [
+						"{{hmy_endpoint_src}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "hmy_sendRawTransaction",
 			"event": [
 				{
@@ -139,6 +189,8 @@
 							"console.log(\"Response\")",
 							"console.log(pm.response.json())",
 							"",
+							"// TODO: write more logic to resend and retest Cx if getCxByHash failed",
+							"",
 							"pm.test(\"Response should not contain errors.\", () => {",
 							"    pm.expect('error' in pm.response.json()).to.equal(false);",
 							"})",
@@ -189,6 +241,8 @@
 							"console.log(\"Response\")",
 							"console.log(pm.response.json())",
 							"",
+							"// TODO: write more logic to resend and retest Cx if getCxByHash failed",
+							"",
 							"pm.test(\"Response should not contain errors.\", () => {",
 							"    pm.expect('error' in pm.response.json()).to.equal(false);",
 							"})",
@@ -219,12 +273,12 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\":\"2.0\",\"method\":\"hmy_getCXReceiptByHash\",\"params\":[\"{{txHash}}\"],\"id\":1}"
+					"raw": "{\"jsonrpc\":\"2.0\",\"method\":\"hmy_resendCx\",\"params\":[\"{{txHash}}\"],\"id\":1}"
 				},
 				"url": {
-					"raw": "{{hmy_endpoint_dst}}",
+					"raw": "{{hmy_endpoint_src}}",
 					"host": [
-						"{{hmy_endpoint_dst}}"
+						"{{hmy_endpoint_src}}"
 					]
 				}
 			},

--- a/test-automation/api-tests/tests/only-explorer/env.json
+++ b/test-automation/api-tests/tests/only-explorer/env.json
@@ -1,1 +1,64 @@
-{"id": "39a65f6d-2c15-47f9-8fab-33aa08aa4ed9", "name": "Automated Test Env (DO NOT CHANGE)", "values": [{"key": "txHash", "value": "0x1bd3d8c23d85676e64508edfb84128e51a0d7e8fa097ed325a3d2ba1d672a6c0", "enabled": true}, {"key": "accountAddress", "value": "one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc", "enabled": true}, {"key": "blockHash", "value": "0x2677e80589215ebede7e4ea1df3988f96751bedc76c09a859aceefb6d30a628f", "enabled": true}, {"key": "blockNumber", "value": "0x5baad", "enabled": true}, {"key": "txIndex", "value": "0x0", "enabled": true}, {"key": "blockTxCount", "value": null, "enabled": true}, {"key": "getBlockByHash_number", "value": "0x5baad", "enabled": true}, {"key": "rawTransaction", "value": "0xf86505808252080180949ad139ffc9f62a7c215766de5901124402cbe531843b9aca008025a0cebf89845c2ed4a6f586f30842071c6b927dc476ce0f64ac3934b850f5e79124a040501686ab1c05ad1373221ed523b8b9bfed4866a6e7a1bad5f6aa7939d42408", "enabled": true}, {"key": "tx_beta_endpoint", "value": "http://e1.t.hmny.io:5000/", "enabled": true}, {"key": "txn_delay", "value": 30, "enabled": true}, {"key": "source_shard", "value": 1, "enabled": true}], "_postman_variable_scope": "environment", "_postman_exported_at": "2019-10-23T21:20:51.340Z", "_postman_exported_using": "Postman/7.9.0"}
+{
+	"id": "39a65f6d-2c15-47f9-8fab-33aa08aa4ed9",
+	"name": "Automated Test Env (DO NOT CHANGE)",
+	"values": [
+		{
+			"key": "txHash",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "accountAddress",
+			"value": "one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc",
+			"enabled": true
+		},
+		{
+			"key": "blockHash",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "blockNumber",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "txIndex",
+			"value": "0x0",
+			"enabled": true
+		},
+		{
+			"key": "blockTxCount",
+			"value": null,
+			"enabled": true
+		},
+		{
+			"key": "getBlockByHash_number",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "rawTransaction",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "tx_beta_endpoint",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "txn_delay",
+			"value": "40",
+			"enabled": true
+		},
+		{
+			"key": "source_shard",
+			"value": "0",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2019-11-13T06:44:05.285Z",
+	"_postman_exported_using": "Postman/7.9.0"
+}

--- a/test-automation/cli-tests/tests/testHmy.py
+++ b/test-automation/cli-tests/tests/testHmy.py
@@ -209,7 +209,7 @@ def test_keys_mnemonics():
 
         try:
             hmy = pexpect.spawn('./hmy', ['keys', 'add', address_name, '--recover', '--passphrase'], env=ENVIRONMENT)
-            hmy.expect("Enter passphrase for account\r\n")
+            hmy.expect("Enter passphrase\r\n")
             hmy.sendline("")
             hmy.expect("Repeat the passphrase:\r\n")
             hmy.sendline("")


### PR DESCRIPTION
* Update newman tests with (corrected) resendCx & latestHeader rpc calls.
* Update newman env vars to default to empty string for clearer fail messages. 
* Add option to test creating a new validator with 1, 10, and 50 BLS keys.
* Generalize source and destination shards so we are not limited to Cx between s0 and s1.
* Small bug fixes/name updates and updated docs.