### PR TITLE
[watchdog] Check if request reply has empty body

### DIFF
--- a/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
@@ -165,11 +165,11 @@ func request(node string, requestBody []byte) ([]byte, []byte, error) {
 	if c != 200 {
 		return nil, requestBody, fmt.Errorf("http status code not 200, received: %d", c)
 	}
-	if len(res.Body()) == 0 {
-		return nil, requestBody, fmt.Errorf("empty reply received")
-	}
 	fasthttp.ReleaseRequest(req)
 	body := res.Body()
+	if len(body) == 0 {
+		return nil, requestBody, fmt.Errorf("empty reply received")
+	}
 	result := make([]byte, len(body))
 	copy(result, body)
 	fasthttp.ReleaseResponse(res)

--- a/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
@@ -165,6 +165,9 @@ func request(node string, requestBody []byte) ([]byte, []byte, error) {
 	if c != 200 {
 		return nil, requestBody, fmt.Errorf("http status code not 200, received: %d", c)
 	}
+	if len(res.Body()) == 0 {
+		return nil, requestBody, fmt.Errorf("empty reply received")
+	}
 	fasthttp.ReleaseRequest(req)
 	body := res.Body()
 	result := make([]byte, len(body))


### PR DESCRIPTION
Noticed BAD_VERSION_STRING error in Watchdog mainnet due to IP listed no longer having a Harmony process & the IP has been recycled by AWS.
IP returns valid header with no body, add check to account for that & add the IP to down machines list.