### PR TITLE
[Watchdog] Update PagerDuty alert system & add logging

### DIFF
--- a/monitoring/harmony-monitor/README.md
+++ b/monitoring/harmony-monitor/README.md
@@ -25,13 +25,12 @@ performance:
 
 # Port for the HTML report
 http-reporter:
-  port: 9090
+  port: 8080
 
 # Numbers assumed as seconds
 shard-health-reporting:
   consensus:
-    warning: 40
-    redline: 300
+    warning: 70
 
 # Needs to be an absolute file path
 # NOTE: The ending of the basename of the file

--- a/monitoring/harmony-monitor/blockchain-watchdog/daemon-cmds.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/daemon-cmds.go
@@ -137,8 +137,7 @@ func generateSampleYAML() *cobra.Command {
 												sampleParams.Performance.WorkerPoolSize = 32
 												sampleParams.Performance.HTTPTimeout = 1
 												sampleParams.HTTPReporter.Port = 8080
-												sampleParams.ShardHealthReporting.Consensus.Warning = 40
-												sampleParams.ShardHealthReporting.Consensus.Redline = 100
+												sampleParams.ShardHealthReporting.Consensus.Warning = 70
 												sampleParams.DistributionFiles.MachineIPList = []string{
 																																					"/home/ec2_user/mainnet/shard0.txt",
 																																					"/home/ec2_user/mainnet/shard1.txt",

--- a/monitoring/harmony-monitor/blockchain-watchdog/pager.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/pager.go
@@ -6,12 +6,22 @@ import (
 	pd "github.com/PagerDuty/go-pagerduty"
 )
 
-func notify(serviceKey, msg string) error {
-	resp, err := pd.CreateEvent(pd.Event{
-		Type:        "trigger",
-		ServiceKey:  serviceKey,
-		Description: msg,
-	})
-	fmt.Println(resp, err)
-	return err
+func notify(serviceKey, incidentKey, chain, msg string, send bool) error {
+	if send {
+		resp, err := pd.ManageEvent(pd.V2Event{
+			RoutingKey: serviceKey,
+			Action:     "trigger",
+			DedupKey:   incidentKey,
+			Payload: &pd.V2Payload{
+				Summary:  incidentKey,
+				Source:   chain,
+				Severity: "critical",
+				Details:  msg,
+			},
+		})
+		fmt.Println(resp, err)
+		return err
+	}
+	fmt.Println(msg)
+	return nil
 }

--- a/monitoring/harmony-monitor/blockchain-watchdog/pager.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/pager.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"fmt"
-
 	pd "github.com/PagerDuty/go-pagerduty"
 )
 
-func notify(serviceKey, incidentKey, chain, msg string, send bool) error {
-	if send {
-		resp, err := pd.ManageEvent(pd.V2Event{
+func notify(serviceKey, incidentKey, chain, msg string) error {
+	_, err := pd.ManageEvent(pd.V2Event{
 			RoutingKey: serviceKey,
 			Action:     "trigger",
 			DedupKey:   incidentKey,
@@ -19,9 +16,5 @@ func notify(serviceKey, incidentKey, chain, msg string, send bool) error {
 				Details:  msg,
 			},
 		})
-		fmt.Println(resp, err)
-		return err
-	}
-	fmt.Println(msg)
-	return nil
+	return err
 }

--- a/monitoring/harmony-monitor/blockchain-watchdog/root.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/root.go
@@ -210,7 +210,6 @@ type watchParams struct {
 	ShardHealthReporting struct {
 		Consensus struct {
 			Warning int `yaml:"warning"`
-			Redline int `yaml:"redline"`
 		} `yaml:"consensus"`
 	} `yaml:"shard-health-reporting"`
 	DistributionFiles struct {
@@ -305,9 +304,6 @@ func (w *watchParams) sanityCheck() error {
 	}
 	if w.ShardHealthReporting.Consensus.Warning == 0 {
 		errList = append(errList, "Missing warmomg under shard-health-reporting, consensus in yaml config")
-	}
-	if w.ShardHealthReporting.Consensus.Redline == 0 {
-		errList = append(errList, "Missing Redline under shard-health-reporting, consensus in yaml config")
 	}
 	if len(errList) == 0 {
 		return nil


### PR DESCRIPTION
* Update PagerDuty alert creation to reduce spam by opening only 1 incident, further notification & alerting people will be handled by PagerDuty escalation policies
* Add logging to shard health monitor
* Replace monitor WaitGroup with Mutex
* Update README & YAML sample to reflect configuration file changes (Removed Consensus.Redline)