### PR TITLE
add mock RPC node server

### DIFF
--- a/monitoring/harmony-monitor/node-mock-rpc/.gitignore
+++ b/monitoring/harmony-monitor/node-mock-rpc/.gitignore
@@ -1,0 +1,2 @@
+./node_modules
+package-lock.json

--- a/monitoring/harmony-monitor/node-mock-rpc/README.md
+++ b/monitoring/harmony-monitor/node-mock-rpc/README.md
@@ -1,0 +1,22 @@
+# Mock RPC server
+This is a small polka server running in node, for the purpose of unit testing Pagerduty
+
+## Running the server
+```bash
+$ npm install
+$ npm start
+```
+
+## Exposed RPC procedures
+- hmy_latestHeader
+```json
+{"jsonrpc":"2.0", "method":"hmy_latestHeader", "params":[], "id":1}
+```
+- hmy_getNodeMetadata
+```json
+{"jsonrpc":"2.0", "method":"hmy_getNodeMetadata", "params":[], "id":1}
+```
+- hmy_getPendingCxReceipts
+```json
+{"jsonrpc":"2.0", "method":"hmy_getPendingCxReceipts", "params":[], "id":1}
+```

--- a/monitoring/harmony-monitor/node-mock-rpc/README.md
+++ b/monitoring/harmony-monitor/node-mock-rpc/README.md
@@ -1,5 +1,5 @@
 # Mock RPC server
-This is a small polka server running in node, for the purpose of unit testing Pagerduty
+This is a small polka server running in node, for the purpose of unit testing our watchdog. 
 
 ## Running the server
 ```bash

--- a/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getNodeMetadata.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getNodeMetadata.js
@@ -1,0 +1,18 @@
+let json = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "blskey": "",
+        "version": "Harmony (C) 2019. harmony, version v4983-v1.2.1-22-g1cea6c62 (ec2-user@ 2020-01-28T00:17:21+0000)",
+        "network": "testnet",
+        "chainid": "2",
+        "is-leader": false,
+        "shard-id": 0,
+        "role": "Unknown"
+    }
+}
+
+exports.hmy_getNodeMetadata = (id) => {
+    json.id = id;
+    return JSON.stringify(json);
+}

--- a/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getNodeMetadata.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getNodeMetadata.js
@@ -6,13 +6,14 @@ let json = {
         "version": "Harmony (C) 2019. harmony, version v4983-v1.2.1-22-g1cea6c62 (ec2-user@ 2020-01-28T00:17:21+0000)",
         "network": "testnet",
         "chainid": "2",
-        "is-leader": false,
+        "is-leader": true,
         "shard-id": 0,
         "role": "Unknown"
     }
 }
 
 exports.hmy_getNodeMetadata = (id) => {
+    //will send identical responses to simulate consensus loss
     json.id = id;
     return JSON.stringify(json);
 }

--- a/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getPendingCxReceipts.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getPendingCxReceipts.js
@@ -1,0 +1,97 @@
+let json = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": [
+        {
+            "receipts": [
+                {
+                    "txHash": "0x8da0bb84419030a118c510f0f8b2729842f4d00e01dd9e8a532e1513514151ee",
+                    "from": "one1d0kw95t6kkljmkk9vu0zv25jraut8ngv5vrs5g",
+                    "to": "one1d0kw95t6kkljmkk9vu0zv25jraut8ngv5vrs5g",
+                    "shardID": 1,
+                    "toShardID": 0,
+                    "amount": 1
+                }
+            ],
+            "merkleProof": {
+                "blockNum": 151632,
+                "blockHash": "0xcdc4c2e55e0b945150c0325afbf436b9013b370b9fe829bd468a48fb08ddbdf8",
+                "shardID": 1,
+                "receiptHash": "0x8c6e20f05d6245e82d933b1870b110a8e5e793b39b5e7f30691b858295415f92",
+                "shardIDs": [
+                    0
+                ],
+                "shardHashes": [
+                    "0x965373de9dc075d85472c83b8e986c8ff8783f856795d9a24ca41c45bb7e98d7"
+                ]
+            },
+            "header": {
+                "Header": {
+                    "parentHash": "0x95d0443f9d49c7fa71860e2f98b8d8abf7f5f96a024928d84af3eb9d9acb3c41",
+                    "miner": "0x75ea17db98f7266c89423a4ea12677822ab269bc",
+                    "stateRoot": "0x9cecdf6fff98ff5a7b2efa3fc0f5780452cb08f4826ff239f1f976c3a503e4ab",
+                    "transactionsRoot": "0x8e6abd7021ce075c9c92195a0eb7f6c2c4ed1697c7c359fb5edd45d8ae9b4f1f",
+                    "receiptsRoot": "0x056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2",
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "number": "0x25050",
+                    "gasLimit": "0x4c4b400",
+                    "gasUsed": "0x5208",
+                    "timestamp": "0x5e3bf530",
+                    "extraData": "0x",
+                    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "hash": "0x1e6c29665ecb1d4a28bb60e2d0e218efe50e2be7a1845486d7d6719be99813af"
+                }
+            },
+            "commitSig": "cspSydmNTCUn/5oovqKoK6omtoMAcaVGopGKptObhGeyierZV4hC9BkJexhXnecBAzDyuOl2/NLPVZXLABgn7HVPugtsGJGjvMSwCEUOdTllln9Bj7TEF3vVXHM22GcK",
+            "commitBitmap": "/wM="
+        },
+        {
+            "receipts": [
+                {
+                    "txHash": "0x8fcdae782c0b94698d65be2278b2588e4c0c876d3056c2c862f08761345519f9",
+                    "from": "one1d0kw95t6kkljmkk9vu0zv25jraut8ngv5vrs5g",
+                    "to": "one1d0kw95t6kkljmkk9vu0zv25jraut8ngv5vrs5g",
+                    "shardID": 1,
+                    "toShardID": 0,
+                    "amount": 1000000000000000000
+                }
+            ],
+            "merkleProof": {
+                "blockNum": 152301,
+                "blockHash": "0x09012f72f3062dd793edb5bd6259bdcd2d982a982d7b2cd062191e94608d0acf",
+                "shardID": 1,
+                "receiptHash": "0xb6ea8a9eb647bd74b60a5f79573685f262c3e4d5bc071c8bb19198d3f549375c",
+                "shardIDs": [
+                    0
+                ],
+                "shardHashes": [
+                    "0xa9839e617e088258adb272bae28d513b3d773225908843777b1f9e35e109d398"
+                ]
+            },
+            "header": {
+                "Header": {
+                    "parentHash": "0x04d5d95e9f06a9e8c8b150fe2355311ecd251476a0180a34f402bd0156fd686b",
+                    "miner": "0x75ea17db98f7266c89423a4ea12677822ab269bc",
+                    "stateRoot": "0xef084f54330ae9f890a257608706e0a13ae26fd8d7d488eb59ca97bbab9f5638",
+                    "transactionsRoot": "0x76b4275cd0eb6275ec984e64bb61320f2d3cd4b25ae3e07da9aafa375e5c9e03",
+                    "receiptsRoot": "0xb92798cd0a0f5b4f1b14822b8d6a9ae3c221157ccf93ad5104adecc315f9db53",
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "number": "0x252ed",
+                    "gasLimit": "0x4c4b400",
+                    "gasUsed": "0x223228",
+                    "timestamp": "0x5e3c0a54",
+                    "extraData": "0x",
+                    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "hash": "0xc151860dcee64832ae2688cc68ca284c26faa8e4f52f5a57069d74d544ecda68"
+                }
+            },
+            "commitSig": "6AsuRyUQJ9JHJFR7owtgnARD8F5ygwF/u1WXpQQ+eua0rAZOq79gMxfpsew/S8YC3UslMe8EoJ4NP7gaw2s6YXfEIXgwsaKK++GLpIi14QU1190Y6Qva3eAiArrCMCgS",
+            "commitBitmap": "/wM="
+        }
+    ]
+}
+
+exports.hmy_getPendingCxReceipts = (id) => {
+    json.id = id;
+    return JSON.stringify(json);
+}

--- a/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getPendingCxReceipts.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getPendingCxReceipts.js
@@ -91,7 +91,39 @@ let json = {
     ]
 }
 
+const resultSample = 
+{
+    "receipts": [
+        {
+            "txHash": "0x8da0bb84419030a118c510f0f8b2729842f4d00e01dd9e8a532e1513514151ee",
+            "from": "one1d0kw95t6kkljmkk9vu0zv25jraut8ngv5vrs5g",
+            "to": "one1d0kw95t6kkljmkk9vu0zv25jraut8ngv5vrs5g",
+            "shardID": 1,
+            "toShardID": 0,
+            "amount": 1
+        }
+    ],
+    "merkleProof": {
+        "blockNum": 151632,
+        "blockHash": "0xcdc4c2e55e0b945150c0325afbf436b9013b370b9fe829bd468a48fb08ddbdf8",
+        "shardID": 1,
+        "receiptHash": "0x8c6e20f05d6245e82d933b1870b110a8e5e793b39b5e7f30691b858295415f92",
+        "shardIDs": [
+            0
+        ],
+        "shardHashes": [
+            "0x965373de9dc075d85472c83b8e986c8ff8783f856795d9a24ca41c45bb7e98d7"
+        ]
+    }
+}
+
 exports.hmy_getPendingCxReceipts = (id) => {
+    // will send a response with a large number of responses to simulate
+    // too many pending cross shard transactions
     json.id = id;
+    size = 1;
+    while(size++ <= 1001){
+        json.result[size] = resultSample
+    }
     return JSON.stringify(json);
 }

--- a/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_latestHeader.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_latestHeader.js
@@ -1,0 +1,21 @@
+let json = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "blockHash": "0xfbb722f572d2b2e8a0e292aa6f91acc73023dde5f281f32b6c5447b5b3102d59",
+        "blockNumber": 165597,
+        "shardID": 1,
+        "leader": "one1wh4p0kuc7unxez2z8f82zfnhsg4ty6dupqyjt2",
+        "viewID": 165594,
+        "epoch": 367,
+        "timestamp": "2020-02-07 18:37:54 +0000 UTC",
+        "unixtime": 1581100674,
+        "lastCommitSig": "d10f5af3e55ccbfea9e336733ffa9dcf4d12594f9b9a825c92e1611ef654cd0cc70966d243f2338a1970243ae9e49c0f8fa15fa138e7bea92a12d10b43af254624751f603f7dd8f0415099854da3678a90d8185076ca904fbbbb9cab63aa0c96",
+        "lastCommitBitmap": "ff03"
+    }
+}
+
+exports.hmy_latestHeader = (id) => {
+    json.id = id;
+    return JSON.stringify(json);
+}

--- a/monitoring/harmony-monitor/node-mock-rpc/app.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/app.js
@@ -1,0 +1,54 @@
+const polka = require('polka');
+const bodyParser = require('body-parser');
+const { PORT } = require('./config');
+const { hmy_latestHeader } = require('./RPC-calls/hmy_latestHeader')
+const { hmy_getNodeMetadata } = require('./RPC-calls/hmy_getNodeMetadata')
+const { hmy_getPendingCxReceipts } = require('./RPC-calls/hmy_getPendingCxReceipts')
+
+//initialize polka
+const app = polka();
+
+//set headers for response
+app.use((req, res, next) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('Vary', 'Origin');
+    next();
+});
+
+//use bodyParser to get JSON from request body
+app.use(bodyParser.json());
+
+//main mock logic on base path
+app.post('/', (req, res) => {
+    const json = req.body;
+
+    //each RPC call is a different switch case
+    switch (json.method) {
+        case 'hmy_latestHeader':
+            res.end(hmy_latestHeader(json.id));
+            break;
+        case 'hmy_getNodeMetadata':
+            res.end(hmy_getNodeMetadata(json.id));
+            break;
+        case 'hmy_getPendingCxReceipts':
+            res.end(hmy_getPendingCxReceipts(json.id));
+            break;
+        default:
+            res.end(JSON.stringify({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32601,
+                    "message": `The method ${json.method} does not exist/is not available`
+                }
+            }));
+            break;
+    }
+})
+
+//start the server
+app.listen(PORT, err => {
+        if (err) throw err;
+        console.log(`Server started on http://localhost:${PORT}/`);
+})

--- a/monitoring/harmony-monitor/node-mock-rpc/config.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    PORT: 9500
+}

--- a/monitoring/harmony-monitor/node-mock-rpc/package.json
+++ b/monitoring/harmony-monitor/node-mock-rpc/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mock-rpc",
+  "version": "1.0.0",
+  "description": "Mock rpc with express for regression testing",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Cem Fahliogullari",
+  "license": "MIT",
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "polka": "^0.5.2"
+  }
+}

--- a/monitoring/harmony-monitor/node-mock-rpc/shard0.txt
+++ b/monitoring/harmony-monitor/node-mock-rpc/shard0.txt
@@ -1,0 +1,1 @@
+localhost


### PR DESCRIPTION
Resolves #339 
# Mock RPC server
This is a small polka server running in node, for the purpose of unit testing Pagerduty

## Running the server
```bash
$ npm install
$ npm start
```

## Exposed RPC procedures
- hmy_latestHeader
```json
{"jsonrpc":"2.0", "method":"hmy_latestHeader", "params":[], "id":1}
```
- hmy_getNodeMetadata
```json
{"jsonrpc":"2.0", "method":"hmy_getNodeMetadata", "params":[], "id":1}
```
- hmy_getPendingCxReceipts
```json
{"jsonrpc":"2.0", "method":"hmy_getPendingCxReceipts", "params":[], "id":1}
```