### PR TITLE
add commit link to version report box

### DIFF
--- a/monitoring/harmony-monitor/blockchain-watchdog/html-generators.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/html-generators.go
@@ -146,7 +146,12 @@ hr:after {
         {{range $key, $value := .}}
           <div class="flex-col center stat-box">
             <a href="#version-{{$key}}">Version-{{$key}}</a>
-            <p>Node Count:{{ len (index $value "records") }}</p>
+            <p>
+              Node Count:{{ len (index $value "records") }}
+              {{ with getCommitId $key }}
+                <a href="https://github.com/harmony-one/harmony/commit/{{.}}">commit</a>
+              {{end}}
+            <p>
           </div>
         {{end}}
         {{end}}

--- a/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"sync"
@@ -240,7 +241,15 @@ func request(node string, requestBody []byte) ([]byte, []byte, error) {
 }
 
 func (m *monitor) renderReport(w http.ResponseWriter, req *http.Request) {
-	t, e := template.New("report").Parse(reportPage(m.chain))
+	t, e := template.New("report").
+		//Adds to template a function to retrieve github commit id from version
+		Funcs(template.FuncMap{
+			"getCommitId": func(version string) string {
+				r := regexp.MustCompile(`v.*g([\d\w]*)`)
+				return r.FindStringSubmatch(version)[1]
+			},
+		}).
+		Parse(reportPage(m.chain))
 	if e != nil {
 		fmt.Println(e)
 		http.Error(w, "could not generate page:"+e.Error(), http.StatusInternalServerError)

--- a/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
@@ -8,9 +8,9 @@ import (
 	"net"
 	"net/http"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -245,8 +245,9 @@ func (m *monitor) renderReport(w http.ResponseWriter, req *http.Request) {
 		//Adds to template a function to retrieve github commit id from version
 		Funcs(template.FuncMap{
 			"getCommitId": func(version string) string {
-				r := regexp.MustCompile(`v.*g([\d\w]*)`)
-				return r.FindStringSubmatch(version)[1]
+				r := strings.Split(version, `-g`)
+				r = strings.Split(r[len(r)-1], "-")
+				return r[0]
 			},
 		}).
 		Parse(reportPage(m.chain))


### PR DESCRIPTION
closes #380 

## Procedure
- Add ~regexp~ strings as import to reporting-server.go
- Add function to html template that uses ~regexp~ strings.Split to pull commit id from version information
- Use function to add a github link to the commit next to Node Count in the report boxes

### ~Assumptions~
- ~The layout of the version field will not change to invalidate the regexp `v.*g([\d\w]*)`~