### PR TITLE
Watchdog & Status Page updates

### DIFF
--- a/monitoring/harmony-monitor/blockchain-watchdog/html-generators.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/html-generators.go
@@ -422,6 +422,7 @@ hr:after {
 			<table class="sortable-theme-bootstrap report-table" data-sortable>
 				<thead>
 		<tr>
+			<th>Address</th>
 			<th>BLSKey</th>
 			<th>Is Harmony Node</th>
 			<th>Voting Power</th>
@@ -432,6 +433,7 @@ hr:after {
 					{{ range .Committee }}
 					{{ with . }}
 					<tr class="prev-harmony-node-{{$Decider.ShardID}}-{{.IsHarmonyNode}}">
+						<td>{{.Address}} </td>
 						<td>{{.BLSKey}} </td>
 						<td>{{.IsHarmonyNode}} </td>
 						<td>{{.VotingPower}} </td>

--- a/monitoring/harmony-monitor/blockchain-watchdog/html-generators.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/html-generators.go
@@ -211,7 +211,7 @@ hr:after {
         </thead>
         <tbody>
         {{range .NoReply}}
-          <tr>
+          <tr style="background-color:#F0B4B4;">
             <td>{{.IP}}</td>
             <td>{{.ShardID}}</td>
             <td>{{.RPCPayload}}</td>

--- a/monitoring/status-page/networks.txt
+++ b/monitoring/status-page/networks.txt
@@ -1,0 +1,3 @@
+Mainnet,mainnet
+Long Running Testnet,testnet
+Open Staking Testnet,staking

--- a/monitoring/status-page/networks.txt
+++ b/monitoring/status-page/networks.txt
@@ -1,3 +1,4 @@
-Mainnet,mainnet
-Long Running Testnet,testnet
-Open Staking Testnet,staking
+# Network Name, Watchdog Chain Name, Explorer Link, Staking Dashboard Link, Endpoint tag
+Mainnet, mainnet, https://explorer.harmony.one, , t
+Long Running Testnet, testnet, https://explorer.testnet.harmony.one, , lrtn
+Open Staking Testnet, staking, https://explorer.os.hmny.io, https://staking.harmony.one, os

--- a/monitoring/status-page/status/routes.py
+++ b/monitoring/status-page/status/routes.py
@@ -3,24 +3,33 @@ import json
 import requests
 from flask import render_template
 from status import app
+from collections import namedtuple
+
+NetworkInfo = namedtuple('NetworkInfo', ['name', 'watchdog', 'explorer', 'staking', 'endpoint'])
 
 watchdog = 'http://watchdog.hmny.io/status-%s'
+endpoint = 'https://api.s%s.%s.hmny.io'
 
 @app.route('/status')
 def status():
 
     with open('networks.txt', 'r') as f:
-        network_list = [x.strip().split(',') for x in f]
+        network_list = [NetworkInfo(*[y.strip() for y in x.strip().split(',')]) for x in f if not x[0] == '#']
 
     statuses = {}
     for n in network_list:
-        r = requests.get(watchdog % n[1], auth=('harmony', 'harmony.one'))
-        statuses[n[0]] = {}
+        r = requests.get(watchdog % n.watchdog, auth=('harmony', 'harmony.one'))
+        statuses[n.name] = {}
+        statuses[n.name]['block'] = {}
         for result in r.json():
-            statuses[n[0]][result["shard-id"]] = result
+            statuses[n.name]['block'][result['shard-id']] = result
+            statuses[n.name]['block'][result['shard-id']]['endpoint'] = endpoint % (result['shard-id'], n.endpoint)
+        statuses[n.name]['explorer-link'] = n.explorer
+        statuses[n.name]['staking-link'] = n.staking
 
+    # Sort output by ShardID
     for net in statuses.keys():
-        for k in statuses[net]:
-            statuses[net] = {key: value for key, value in sorted(statuses[net].items(), key = lambda item: item[1]["shard-id"])}
+        for k in statuses[net]['block']:
+            statuses[net]['block'] = {key: value for key, value in sorted(statuses[net]['block'].items(), key = lambda item: item[1]['shard-id'])}
 
     return render_template('status.html.j2', data = statuses)

--- a/monitoring/status-page/status/routes.py
+++ b/monitoring/status-page/status/routes.py
@@ -5,10 +5,13 @@ from flask import render_template
 from status import app
 
 watchdog = 'http://watchdog.hmny.io/status-%s'
-network_list = [('Mainnet', 'mainnet'),('Long Running Testnet', 'testnet'), ('Open Staking Testnet', 'staking')]
 
 @app.route('/status')
 def status():
+
+    with open('networks.txt', 'r') as f:
+        network_list = [x.strip().split(',') for x in f]
+
     statuses = {}
     for n in network_list:
         r = requests.get(watchdog % n[1], auth=('harmony', 'harmony.one'))

--- a/monitoring/status-page/status/static/styles.css
+++ b/monitoring/status-page/status/static/styles.css
@@ -108,7 +108,10 @@ a:hover {
 .flex-col {
   display: flex;
   flex-direction: column;
-  align-items: center;
+}
+.flex-row {
+  display: flex;
+  justify-content: space-between;
 }
 .hmy-bg {
     background: linear-gradient(to right top, #00aee9, #4fe7c8);

--- a/monitoring/status-page/status/static/styles.css
+++ b/monitoring/status-page/status/static/styles.css
@@ -105,6 +105,11 @@ a {
 a:hover {
     text-decoration: underline;
 }
+.flex-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 .hmy-bg {
     background: linear-gradient(to right top, #00aee9, #4fe7c8);
 }

--- a/monitoring/status-page/status/templates/status.html.j2
+++ b/monitoring/status-page/status/templates/status.html.j2
@@ -53,13 +53,27 @@
             <header>
               <h1>Network Status</h1>
             </header>
-
+            <div style="padding-top: 4px; padding-left: 20px">
+              <p><font size="2">NOTE: If everything is offline, services are likely being restarted. Check back in 2 minutes.</font></p>
+            </div>
 
             <div class="card flex-col">
             {% for net in data.keys() %}
             <span style="width: 95%;margin-right: 0;">
               <details open>
                 <summary>{{ net }}</summary>
+                <div class="flex-col" style="padding-bottom: 4px">
+                  <div class="flex-row">
+                    <p>
+                    {% if data[net]['explorer-link'] %}
+                      <a href="{{ data[net]['explorer-link'] }}">Block Explorer</a>
+                    {% endif %}
+                    {% if data[net]['staking-link'] %}
+                      // <a href="{{ data[net]['staking-link'] }}">Staking Dashboard</a>
+                    {% endif %}
+                    </p>
+                  </div>
+                </div>
                 <div class="flex-col">
                   <table style = "width: 95%;">
                     <tr>
@@ -67,25 +81,27 @@
                       <th>Status</th>
                       <th>Block</th>
                       <th>Epoch</th>
-                      <th>Timestamp</th>
+                      <th>Timestamp (UTC)</th>
                       <th>Leader</th>
+                      <th>Endpoint</th>
                     </tr>
-                    {% for value in data[net] %}
+                    {% for value in data[net]['block'] %}
                     <tr>
-                      <td>{{ data[net][value]["shard-id"] }}</td>
-                      {% if data[net][value]["consensus-status"] %}
+                      <td>{{ data[net]['block'][value]['shard-id'] }}</td>
+                      {% if data[net]['block'][value]['consensus-status'] %}
                         <td><font color="green">Online</font></td>
                       {% else %}
                         <td><font color="red">Offline</font></td>
                       {% endif %}
-                      <td>{{ data[net][value]["current-block-number"] }}</td>
-                      <td>{{ data[net][value]["current-epoch"] }}</td>
-                      <td>{{ data[net][value]["block-timestamp"] }}</td>
+                      <td>{{ data[net]['block'][value]['current-block-number'] }}</td>
+                      <td>{{ data[net]['block'][value]['current-epoch'] }}</td>
+                      <td>{{ data[net]['block'][value]['block-timestamp'][:-10] }}</td>
                       <td style="font-family:'Courier New', monospaced; font-weight: 550;">
-                        {{ data[net][value]["leader-address"] }}
+                        {{ data[net]['block'][value]['leader-address'] }}
                       </td>
-                      {% endfor %}
+                      <td> {{ data[net]['block'][value]['endpoint'] }} </td>
                     </tr>
+                    {% endfor %}
                   </table>
                 </div>
               </details>

--- a/monitoring/status-page/status/templates/status.html.j2
+++ b/monitoring/status-page/status/templates/status.html.j2
@@ -55,19 +55,19 @@
             </header>
 
 
-            <div class="card">
+            <div class="card flex-col">
             {% for net in data.keys() %}
-            <section>
+            <span style="width: 95%;margin-right: 0;">
               <details open>
                 <summary>{{ net }}</summary>
-                <div>
-                  <table style = "width: 95%">
+                <div class="flex-col">
+                  <table style = "width: 95%;">
                     <tr>
                       <th>Shard</th>
                       <th>Status</th>
-                      <th>Current Block</th>
-                      <th>Current Epoch</th>
-                      <th>Block Timestamp</th>
+                      <th>Block</th>
+                      <th>Epoch</th>
+                      <th>Timestamp</th>
                       <th>Leader</th>
                     </tr>
                     {% for value in data[net] %}
@@ -81,13 +81,15 @@
                       <td>{{ data[net][value]["current-block-number"] }}</td>
                       <td>{{ data[net][value]["current-epoch"] }}</td>
                       <td>{{ data[net][value]["block-timestamp"] }}</td>
-                      <td>{{ data[net][value]["leader-address"] }}</td>
+                      <td style="font-family:'Courier New', monospaced; font-weight: 550;">
+                        {{ data[net][value]["leader-address"] }}
+                      </td>
                       {% endfor %}
                     </tr>
                   </table>
                 </div>
               </details>
-            </section>
+            </span>
             {% endfor %}
             </div>
           </div>


### PR DESCRIPTION
```
[watchdog] Show ONE address in Previous Committee
[status-page] Add links to Block Explorer & Staking Dashboard
                        Include API endpoints for each shard & network
[status-page] Update CSS to display leader address in monospaced font
[status-page] Read list of networks from a file
[watchdog] Change background color of down nodes to red
```