### PR TITLE
[watchdog] Compute average time of block processing, Accept bad block from blockchain webhook

### DIFF
--- a/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/reporting-server.go
@@ -969,6 +969,12 @@ func (m *monitor) statusJSON(w http.ResponseWriter, req *http.Request) {
 	json.NewEncoder(w).Encode(m.statusSnapshot())
 }
 
+func (m *monitor) badBlocksJSON(w http.ResponseWriter, req *http.Request) {
+	m.currentBadBlocks.Lock()
+	defer m.currentBadBlocks.Unlock()
+	json.NewEncoder(w).Encode(m.currentBadBlocks.blocks)
+}
+
 func (m *badBlockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var issue badBlock
 
@@ -996,6 +1002,7 @@ func (m *monitor) startReportingHTTPServers(instrs *instruction) {
 	http.HandleFunc("/report-download-"+instrs.Network.TargetChain, m.produceCSV)
 	http.HandleFunc("/network-"+instrs.Network.TargetChain, m.networkSnapshotJSON)
 	http.HandleFunc("/status-"+instrs.Network.TargetChain, m.statusJSON)
+	http.HandleFunc("/bad-blocks-"+instrs.Network.TargetChain, m.badBlocksJSON)
 	http.ListenAndServe(":"+strconv.Itoa(instrs.HTTPReporter.Port), nil)
 	http.ListenAndServe(":"+strconv.Itoa(instrs.BadBlockHandler.Port), &m.badBlockHandler)
 	go func() {

--- a/monitoring/harmony-monitor/blockchain-watchdog/root.go
+++ b/monitoring/harmony-monitor/blockchain-watchdog/root.go
@@ -156,6 +156,7 @@ func (service *Service) monitorNetwork() error {
 	// set up channel on which to send accepted connections
 	listen := make(chan net.Conn, 100)
 	go service.startReportingHTTPServers(service.instruction)
+	go service.startListeningChainEvents(service.instruction)
 	go acceptConnection(listener, listen)
 	// loop work cycle with accept connections or interrupt
 	// by system signal

--- a/monitoring/harmony-monitor/go.mod
+++ b/monitoring/harmony-monitor/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ahmetb/go-linq v3.0.0+incompatible
 	github.com/ahmetb/go-linq/v3 v3.1.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/gorilla/websocket v1.4.1 // indirect
+	github.com/gorilla/websocket v1.4.1
 	github.com/harmony-one/go-sdk v0.0.0-20190917171649-83ae0c1dddc7
 	github.com/spf13/cobra v0.0.5
 	github.com/takama/daemon v0.11.0

--- a/monitoring/harmony-monitor/go.mod
+++ b/monitoring/harmony-monitor/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ahmetb/go-linq v3.0.0+incompatible
 	github.com/ahmetb/go-linq/v3 v3.1.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/harmony-one/go-sdk v0.0.0-20190917171649-83ae0c1dddc7
 	github.com/spf13/cobra v0.0.5
 	github.com/takama/daemon v0.11.0

--- a/monitoring/harmony-monitor/go.sum
+++ b/monitoring/harmony-monitor/go.sum
@@ -151,6 +151,8 @@ github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=

--- a/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getNodeMetadata.js
+++ b/monitoring/harmony-monitor/node-mock-rpc/RPC-calls/hmy_getNodeMetadata.js
@@ -1,19 +1,20 @@
 let json = {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "result": {
-        "blskey": "",
-        "version": "Harmony (C) 2019. harmony, version v4983-v1.2.1-22-g1cea6c62 (ec2-user@ 2020-01-28T00:17:21+0000)",
-        "network": "testnet",
-        "chainid": "2",
-        "is-leader": true,
-        "shard-id": 0,
-        "role": "Unknown"
-    }
-}
+  jsonrpc: '2.0',
+  id: 1,
+  result: {
+    blskey: '',
+    version:
+      'Harmony (C) 2020. harmony, version v4983-v1.2.1-22-g1cea6c62 (ec2-user@ 2020-01-28T00:17:21+0000)',
+    network: 'testnet',
+    chainid: '2',
+    'is-leader': true,
+    'shard-id': 0,
+    role: 'Unknown',
+  },
+};
 
-exports.hmy_getNodeMetadata = (id) => {
-    //will send identical responses to simulate consensus loss
-    json.id = id;
-    return JSON.stringify(json);
-}
+exports.hmy_getNodeMetadata = id => {
+  //will send identical responses to simulate consensus loss
+  json.id = id;
+  return JSON.stringify(json);
+};


### PR DESCRIPTION
1. Finish updating yaml in README
2. Create the HTML/CSS for the table of bad blocks that came in via webhook, only show this table if there is at least one bad block in the slice. 
3. Deploy with @LeoHChen a yaml file via restarting some nodes on OSTN with a webhook path that will call the handler on watchdog, something like: 

```yaml
protocol-hooks:
  on-cannot-commit-block: http://watchdog.hmny.io/on-cannot-commit-blocks
```

And make the route via nginx be handled by the http server running on what port we pick in the yaml file for watchdog, localhost:<FROM_WATCHDOG_YAML>